### PR TITLE
Add minimum stock attribute

### DIFF
--- a/src/bda/plone/cart/interfaces.py
+++ b/src/bda/plone/cart/interfaces.py
@@ -184,6 +184,10 @@ class ICartItemStock(Interface):
     overbook = Attribute(u"Allowed overbooking count. ``None`` "
                          u"means unlimited")
 
+    minimum_stock = Attribute(u"Limit of minimum items in stock. ``None`` "
+                         u"means unlimited")
+
+
 
 class ICartItemPreviewImage(Interface):
     """Provides preview image url for cart item

--- a/src/bda/plone/cart/interfaces.py
+++ b/src/bda/plone/cart/interfaces.py
@@ -184,7 +184,7 @@ class ICartItemStock(Interface):
     overbook = Attribute(u"Allowed overbooking count. ``None`` "
                          u"means unlimited")
 
-    minimum_stock = Attribute(u"Limit of minimum items in stock. ``None`` "
+    stock_warning_threshold = Attribute(u"Item stock warning threshold. ``None`` "
                          u"means unlimited")
 
 


### PR DESCRIPTION
Use case:
* Webshop administrator doesn't notice that items are getting out of stock.

Based on Pull request: https://github.com/bluedynamics/bda.plone.orders/pull/31

This is necessary to make the minimum stock work in a dedicated context.